### PR TITLE
EN-4817: Support default values in comp. strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,26 @@ For a _geocoded_ computed column
 * source columns must be `text` columns.\*
 
 The computation strategy has the following _required_\*\* parameter:
-* `"country_default"`: country address default value
+* `"defaults.country"`: country address default value
 
-\*\* A customer can set a domain wide default for `country_default` which will be used unless it is overridden at the computation strategy level. If there is no domain default and the parameter is not provided to the computation strategy, it will be inserted with value `"US"`.
+\*\* A customer can set a domain wide default for `defaults.country` which will be used unless it is overridden at the computation strategy level. If there is no domain default and the parameter is not provided to the computation strategy, it will be inserted with value `"US"`.
 
 And the following _optional_ parameters:
 
 Source columns:
-* `"address"`: field name of the address source column
-* `"locality"`: field name of the locality source column
-* `"subregion"`: field name of the subregion source column
-* `"region"`: field name of the region source column
-* `"postal_code"`: field name of the postal code source column
-* `"country"`: field name of country source column
+* `"sources.address"`: field name of the address source column
+* `"sources.locality"`: field name of the locality source column
+* `"sources.subregion"`: field name of the subregion source column
+* `"sources.region"`: field name of the region source column
+* `"sources.postal_code"`: field name of the postal code source column
+* `"sources.country"`: field name of country source column
 
 Default values:
-* `"address_default"`: address default value
-* `"locality_default"`: locality default value
-* `"subregion_default"`: subregion default value
-* `"region_default"`: region default value
-* `"postal_code_default"`: postal code default value
+* `"defaults.address"`: address default value
+* `"defaults.locality"`: locality default value
+* `"defaults.subregion"`: subregion default value
+* `"defaults.region"`: region default value
+* `"defaults.postal_code"`: postal code default value
 
 The source column field names in the `computationStrategy.source_columns` and `computationStrategy.parameters` must match, further those columns must exist and cannot be deleted until the computed column is first deleted.
 
@@ -54,12 +54,16 @@ For example:
     "type": "geocoding",
     "source_columns": [ "street_address", "city", "state", "zip_code"],
     "parameters": {
-      "address": "street_address",
-      "locality": "city",
-      "region": "state",
-      "postal_code": "zip_code",
-      "region_default": "WA",
-      "country_default": "US",
+      "sources": {
+        "address": "street_address",
+        "locality": "city",
+        "region": "state",
+        "postal_code": "zip_code"
+      },
+      "defaults": {
+        "region": "WA",
+        "country": "US"
+      },
       "version": "v1"
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,75 @@
-# Geocoding-secondary
-Geocoding Secondary Store
+## geocoding-secondary
+Asynchronous NBE geocoding service
+
+## Design
+**geocoding-secondary** is a _feedback_ secondary. [What is a feedback secondary?](https://docs.google.com/document/d/1feNpBc8mbEi5CF7sDmvASkMyISJhLofbPuFM4jaNL14/edit) Like other secondaries it runs as an instance of secondary-watcher. But instead of writing to its own store, it _feeds back_ its computations to `truth` by posting mutation scripts to data-coordinator.
+
+## Usage
+**geocoding-secondary** operates on _computed point_ columns with computation strategy `"type" : "geocoding"`. It geocodes the value of the target point column from an address constructed from the text source columns described in the `computationStrategy`.
+
+#### Computed Column Definition
+For a _geocoded_ computed column
+* the column `dataTypeName` must be `"point"`.
+* the column `computationStrategy.type` must be `"geocoding"`.
+* source columns must be `text` columns.\*
+
+The computation strategy has the following _required_\*\* parameter:
+* `"country_default"`: country address default value
+
+\*\* A customer can set a domain wide default for `country_default` which will be used unless it is overridden at the computation strategy level. If there is no domain default and the parameter is not provided to the computation strategy, it will be inserted with value `"US"`.
+
+And the following _optional_ parameters:
+
+Source columns:
+* `"address"`: field name of the address source column
+* `"locality"`: field name of the locality source column
+* `"subregion"`: field name of the subregion source column
+* `"region"`: field name of the region source column
+* `"postal_code"`: field name of the postal code source column
+* `"country"`: field name of country source column
+
+Default values:
+* `"address_default"`: address default value
+* `"locality_default"`: locality default value
+* `"subregion_default"`: subregion default value
+* `"region_default"`: region default value
+* `"postal_code_default"`: postal code default value
+
+The source column field names in the `computationStrategy.source_columns` and `computationStrategy.parameters` must match, further those columns must exist and cannot be deleted until the computed column is first deleted.
+
+If a default value is specified for an address part, then that value will be used in the computation always if no source column is specified for that address part, otherwise it will be used as default value for that address part in the computation for null values at the row level.
+
+Version:
+* `"version"`: api version, this version will be `"v1"`
+
+If the api version is not provided the version will default to the current version and be inserted into the computation strategy.
+
+For example:
+```
+{
+  "name": "Location",
+  "dataTypeName": "point",
+  "fieldName": "location",
+  "computationStrategy": {
+    "type": "geocoding",
+    "source_columns": [ "street_address", "city", "state", "zip_code"],
+    "parameters": {
+      "address": "street_address",
+      "locality": "city",
+      "region": "state",
+      "postal_code": "zip_code",
+      "region_default": "WA",
+      "country_default": "US",
+      "version": "v1"
+    }
+  }
+}
+```
+
+\* `postal_code` source columns may be `number` columns, but really postal codes _should_ be of type `text`.
+
+## Running
+To run the tests
+```
+sbt test
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a _geocoded_ computed column
 The computation strategy has the following _required_\*\* parameter:
 * `"defaults.country"`: country address default value
 
-\*\* A customer can set a domain wide default for `defaults.country` which will be used unless it is overridden at the computation strategy level. If there is no domain default and the parameter is not provided to the computation strategy, it will be inserted with value `"US"`.
+\*\* A superadmin can set a [domain wide default](https://github.com/socrata-platform/geocoding-secondary/blob/aerust/EN-4817/README.md#domain-wide-defaults) for `defaults.country` which will be used unless it is overridden at the computation strategy level. If there is no domain default and the parameter is not provided to the computation strategy, it will be inserted with value `"US"`.
 
 And the following _optional_ parameters:
 
@@ -71,6 +71,23 @@ For example:
 ```
 
 \* `postal_code` source columns may be `number` columns, but really postal codes _should_ be of type `text`.
+
+##### Domain Wide Defaults
+A superadmin can set a domain wide default for any of the default values. These domain wide default values will be used unless overridden in a computation strategy.
+
+These can be set through the admin panel by providing the property to the `"geocoding"` configuration:
+
+* key: `"defaults"`  
+* value:
+  A json object with the optional fields:
+  - `"address"`
+  - `"locality"`
+  - `"subregion"`
+  - `"region"`
+  - `"postal_code"`
+  - `"country"`
+
+Setting a domain wide default for `"country"` is encouraged as otherwise `"computationStrategy.defaults.country"` will be defaulted to `"US"`.
 
 ## Running
 To run the tests

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ val astyanaxThrift = astyanaxExcludes("com.netflix.astyanax" % "astyanax-thrift"
 
 val rojomaJsonV3            = "com.rojoma"  %% "rojoma-json-v3"             % "3.5.0"
 
-val geocoders               = "com.socrata" %% "geocoders"                  % "1.0.6"
+val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.0"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.1"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.5"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 
@@ -21,7 +21,6 @@ val typesafeConfig          = "com.typesafe" % "config"                     % "1
 
 lazy val commonSettings = Seq(
   organization := "com.socrata",
-  version := "0.0.0",
   scalaVersion := "2.10.4"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ val astyanaxThrift = astyanaxExcludes("com.netflix.astyanax" % "astyanax-thrift"
 
 val rojomaJsonV3            = "com.rojoma"  %% "rojoma-json-v3"             % "3.5.0"
 
+val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0.0.2"
+
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.0"
 
 val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.5"
@@ -32,6 +34,7 @@ lazy val root = (project in file(".")).
       astyanaxCassandra,
       astyanaxThrift,
       rojomaJsonV3,
+      computationStrategies,
       geocoders,
       dataCoordinator,
       socrataCuratorUtils,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.1_6329_11316ad4
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.5_6506_8bc696db
 
 # TODO expose JMX
 # EXPOSE

--- a/src/test/scala/com.socrata.geocodingsecondary/GeocodingHandlerTest.scala
+++ b/src/test/scala/com.socrata.geocodingsecondary/GeocodingHandlerTest.scala
@@ -1,0 +1,167 @@
+package com.socrata.geocodingsecondary
+
+import com.socrata.datacoordinator.secondary.feedback.ComputationFailure
+import com.socrata.geocoders.{OptionalGeocoder, InternationalAddress, LatLon}
+import org.scalatest.{ShouldMatchers, FunSuite}
+
+class GeocodingHandlerTest extends FunSuite with ShouldMatchers {
+
+  import TestData._
+
+  val user = "geocoding-secondary"
+  val retries = 5
+
+  val geocoder = new OptionalGeocoder {override def batchSize: Int = 100 // doesn't matter
+
+    override def geocode(addresses: Seq[Option[InternationalAddress]]): Seq[Option[LatLon]] =
+      addresses.map{ address =>
+        if (address == badAddress) throw new Exception("Bad address!") else knownAddresses.get(address)
+      }
+  }
+
+  val handler = new GeocodingHandler(geocoder, retries = retries)
+
+  test("Reports user as \"geocoding-secondary\"") {
+    handler.user should be(user)
+  }
+
+  test("Reports correct number of retries") {
+    handler.computationRetries should be(retries)
+  }
+
+  test("Accepts computation strategies of type \"geocoding\"") {
+    handler.matchesStrategyType(geocodingStrategyType) should be(true)
+  }
+
+  // tests for GeocodingHandler.transform(.)
+
+  // note: this shouldn't happen with proper validation up stream
+  test("Should transform a row missing source columns to an empty address") {
+    val strategy = strategyInfo(sourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(emptyAddress, baseRow, targetColId)
+    handler.transform(baseRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  // note: the list source columns ids in the computation strategy should match the
+  // source column ids given per address part, but this is not currently validated
+  // anywhere, so we should handle these cases gracefully
+
+  test("Should transform an row missing source columns with no optional parameters to an empty address") {
+    val strategy = strategyInfo(sourceColumnIds, emptyParameters)
+    val expected = GeocodeRowInfo(emptyAddress, baseRow, targetColId)
+    handler.transform(baseRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a full row with no optional parameters to an empty address") {
+    val strategy = strategyInfo(sourceColumnIds, emptyParameters)
+    val expected = GeocodeRowInfo(emptyAddress, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  // i.e. the column ids passed in the computation strategy are not actually used in the computation
+  // only the values given in the `parameters` json blob are used
+  test("Should transform a full row with no source columns") {
+    val strategy = strategyInfo(emptySourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with a full address") {
+    val strategy = strategyInfo(sourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with a SoQLNull value") {
+    val strategy = strategyInfo(sourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(socrataAddressNoRegion, socrataRowNoRegion, targetColId)
+    handler.transform(socrataRowNoRegion, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with partial optional parameters") {
+    val strategy = strategyInfo(sourceColumnIds, parametersNoPostalCode)
+    val expected = GeocodeRowInfo(socrataAddressNoPostalCode, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with SoQLNumber zip column") {
+    val strategy = strategyInfo(sourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRowPostalCodeAsNumber, targetColId)
+    handler.transform(socrataRowPostalCodeAsNumber, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with SoQLNull valued country column and use default") {
+    val strategy = strategyInfo(sourceColumnIds, parameters)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRowNullCountry, targetColId)
+    handler.transform(socrataRowNullCountry, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row with no country column") {
+    val strategy = strategyInfo(sourceColumnIds, parametersNoCountry)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row using a default parameter value in place of a SoQLNull") {
+    val strategy = strategyInfo(sourceColumnIds, parametersDefaultRegion)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRowNoRegion, targetColId)
+    handler.transform(socrataRowNoRegion, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row using a default parameter value with no source column") {
+    val strategy = strategyInfo(sourceColumnIds, parametersDefaultRegion)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRowNoRegion, targetColId)
+    handler.transform(socrataRowNoRegion, targetColId, strategy, cookieSchema(strategy)) should be (expected)
+  }
+
+  test("Should transform a row using a default country parameter") {
+    val strategy1 = strategyInfo(sourceColumnIds, parametersDefaultCountry)
+    val expected1 = GeocodeRowInfo(socrataAddressUnitedStates, socrataRowUnitedStates, targetColId)
+    handler.transform(socrataRowUnitedStates, targetColId, strategy1, cookieSchema(strategy1)) should be (expected1)
+
+    val strategy2 = strategyInfo(sourceColumnIds, parametersOnlyDefaultCountry)
+    val expected2 = GeocodeRowInfo(socrataAddressUnitedStates, socrataRowNullCountry, targetColId)
+    handler.transform( socrataRowNullCountry, targetColId, strategy2, cookieSchema(strategy2)) should be (expected2)
+  }
+
+  test("Should transform a row with extra parameters") {
+    val strategy = strategyInfo(sourceColumnIds, parametersWithExtra)
+    val expected = GeocodeRowInfo(socrataAddress, socrataRow, targetColId)
+    handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy)) should be(expected)
+  }
+
+  test("Should throw a MalformedParametersException when transforming a row with malformed parameters") {
+    intercept[MalformedParametersException] {
+      val strategy = strategyInfo(sourceColumnIds, parametersMalformed)
+      handler.transform(socrataRow, targetColId, strategy, cookieSchema(strategy))
+    }
+  }
+
+  // tests for GeocodingHandler.compute(.)
+
+  test("Should handle compute(.) called with an empty iterator") {
+    handler.compute(Iterator.empty).toSeq should be (Seq.empty)
+  }
+
+  test("Should compute results for both valid and invalid addresses") {
+    val rows = Iterator(
+      (GeocodeRowInfo(emptyAddress, emptyRow, targetColId), 0),
+      (GeocodeRowInfo(socrataAddress, socrataRow, targetColId), 2),
+      (GeocodeRowInfo(socrataDCAddress, socrataDCRow, targetColId), 3),
+      (GeocodeRowInfo(nowhereAddress, nowhereRow, targetColId), 5)
+    )
+    val expected = Seq(
+      ((GeocodeRowInfo(emptyAddress, emptyRow, targetColId), emptyJValue), 0),
+      ((GeocodeRowInfo(socrataAddress, socrataRow, targetColId), socrataJValue), 2),
+      ((GeocodeRowInfo(socrataDCAddress, socrataDCRow, targetColId), socrataDCJValue), 3),
+      ((GeocodeRowInfo(nowhereAddress, nowhereRow, targetColId), nowhereJValue), 5)
+    )
+    handler.compute(rows).toSeq should equal (expected)
+  }
+
+  test("Should throw a ComputationFailure if geocoder throws during compute(.)") {
+    intercept[ComputationFailure] {
+      handler.compute(Iterator((GeocodeRowInfo(badAddress, badAddressRow, targetColId), 0)))
+    }
+  }
+}

--- a/src/test/scala/com.socrata.geocodingsecondary/GeocodingHandlerTest.scala
+++ b/src/test/scala/com.socrata.geocodingsecondary/GeocodingHandlerTest.scala
@@ -114,16 +114,6 @@ class GeocodingHandlerTest extends FunSuite with ShouldMatchers {
     handler.transform(socrataRowNoRegion, targetColId, strategy, cookieSchema(strategy)) should be (expected)
   }
 
-  test("Should transform a row using a default country parameter") {
-    val strategy1 = strategyInfo(sourceColumnIds, parametersDefaultCountry)
-    val expected1 = GeocodeRowInfo(socrataAddressUnitedStates, socrataRowUnitedStates, targetColId)
-    handler.transform(socrataRowUnitedStates, targetColId, strategy1, cookieSchema(strategy1)) should be (expected1)
-
-    val strategy2 = strategyInfo(sourceColumnIds, parametersOnlyDefaultCountry)
-    val expected2 = GeocodeRowInfo(socrataAddressUnitedStates, socrataRowNullCountry, targetColId)
-    handler.transform( socrataRowNullCountry, targetColId, strategy2, cookieSchema(strategy2)) should be (expected2)
-  }
-
   test("Should transform a row with extra parameters") {
     val strategy = strategyInfo(sourceColumnIds, parametersWithExtra)
     val expected = GeocodeRowInfo(socrataAddress, socrataRow, targetColId)

--- a/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
+++ b/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
@@ -43,91 +43,90 @@ object TestData {
   val emptySourceColumnIds = Seq.empty
   val sourceColumnIds = sourceColumns.map(_.userId)
 
+  def parametersSchema(sources: JObject, defaults: JObject) = JObject(Map(
+    "sources" -> sources,
+    "defaults" -> defaults,
+    "version" -> JString("v1")
+  ))
+
+  val baseAddressDefaults = JObject(Map(
+    "country" -> JString("US"))
+  )
+
   // parameters
-  val emptyParameters = JObject(Map(
-    "country_default" -> JString("US")
-  ))
+  val emptyParameters = parametersSchema(JObject.canonicalEmpty, baseAddressDefaults)
 
-  val parameters = JObject(Map(
+  val fullAddressSource = JObject(Map(
     "address" -> JString(address.userId.underlying),
     "locality" -> JString(locality.userId.underlying),
     "region" -> JString(region.userId.underlying),
     "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "country_default" -> JString("US")
+    "country" -> JString(country.userId.underlying)
   ))
 
-  val parametersNoPostalCode = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "country_default" -> JString("US")
-  ))
+  val parameters = parametersSchema(fullAddressSource, baseAddressDefaults)
 
-  val parametersNoCountry = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country_default" -> JString("US")
-  ))
+  val parametersNoPostalCode = parametersSchema(
+    JObject(Map(
+      "address" -> JString(address.userId.underlying),
+      "locality" -> JString(locality.userId.underlying),
+      "region" -> JString(region.userId.underlying),
+      "country" -> JString(country.userId.underlying))),
+    baseAddressDefaults
+  )
 
-  val parametersDefaultRegion = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "region_default" -> JString("WA"),
-    "country_default" -> JString("US")
-  ))
+  val parametersNoCountry = parametersSchema(
+    JObject(Map(
+      "address" -> JString(address.userId.underlying),
+      "locality" -> JString(locality.userId.underlying),
+      "region" -> JString(region.userId.underlying),
+      "postal_code" -> JString(postalCode.userId.underlying))),
+    baseAddressDefaults
+  )
 
-  val parametersOnlyDefaultRegion = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "region_default" -> JString("WA"),
-    "country_default" -> JString("US")
-  ))
+  val defaultRegion = JObject(Map(
+    "region" -> JString("WA"),
+    "country" -> JString("US"))
+  )
 
-  val parametersDefaultCountry = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "country_default" -> JString("United States")
-  ))
+  val parametersDefaultRegion = parametersSchema(
+    fullAddressSource,
+    defaultRegion
+  )
 
-  val parametersOnlyDefaultCountry = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country_default" -> JString("United States")
-  ))
+  val parametersOnlyDefaultRegion = parametersSchema(
+    JObject(Map(
+      "address" -> JString(address.userId.underlying),
+      "locality" -> JString(locality.userId.underlying),
+      "postal_code" -> JString(postalCode.userId.underlying),
+      "country" -> JString(country.userId.underlying))),
+    defaultRegion
+  )
 
   val parametersWithExtra = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JString(region.userId.underlying),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "country_default" -> JString("US"),
-    "extra" -> JNull
+    "sources" -> JObject(Map(
+      "address" -> JString(address.userId.underlying),
+      "locality" -> JString(locality.userId.underlying),
+      "region" -> JString(region.userId.underlying),
+      "postal_code" -> JString(postalCode.userId.underlying),
+      "extra" -> JNumber(5))),
+    "defaults" -> JObject(Map(
+      "country" -> JString("US"),
+      "extra" -> JNull)),
+    "version" -> JString("v1"),
+    "extra" -> JNull,
+    "extra1" -> JString("extra")
   ))
 
-  val parametersMalformed = JObject(Map(
-    "address" -> JString(address.userId.underlying),
-    "locality" -> JString(locality.userId.underlying),
-    "region" -> JNumber(666),
-    "postal_code" -> JString(postalCode.userId.underlying),
-    "country" -> JString(country.userId.underlying),
-    "country_default" -> JString("US"),
-    "extra" -> JNull
-  ))
+  val parametersMalformed = parametersSchema(
+    JObject(Map(
+      "address" -> JString(address.userId.underlying),
+      "locality" -> JString(locality.userId.underlying),
+      "region" -> JNumber(666),
+      "postal_code" -> JString(postalCode.userId.underlying),
+      "country" -> JString(country.userId.underlying))),
+    baseAddressDefaults
+  )
 
   def cookieSchema(strategyInfo: ComputationStrategyInfo) = CookieSchema(
     dataVersion = DataVersion(44),

--- a/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
+++ b/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
@@ -1,0 +1,212 @@
+package com.socrata.geocodingsecondary
+
+import com.rojoma.json.v3.ast.{JNumber, JNull, JString, JObject}
+import com.socrata.datacoordinator.id.{StrategyType, ColumnId, UserColumnId}
+import com.socrata.datacoordinator.secondary.ComputationStrategyInfo
+import com.socrata.datacoordinator.secondary.feedback.{CopyNumber, DataVersion, CookieSchema}
+import com.socrata.datacoordinator.util.collection.ColumnIdMap
+import com.socrata.geocoders.{InternationalAddress, LatLon}
+import com.socrata.soql.types.{SoQLNumber, SoQLID, SoQLNull, SoQLText}
+
+object TestData {
+
+  val geocodingStrategyType = StrategyType("geocoding")
+
+  def strategyInfo(sourceColumnIds: Seq[UserColumnId], parameters: JObject) =
+    ComputationStrategyInfo(geocodingStrategyType, sourceColumnIds, parameters)
+
+  case class Column(id: ColumnId, userId: UserColumnId)
+
+  def column(id: Long, userId: String) = Column(new ColumnId(id), new UserColumnId(userId))
+
+  // id column
+  val id = column(1, ":id")
+
+  // source columns
+  val address    = column(2, "addr-esss")
+  val locality   = column(3, "loca-lity")
+  val subregion  = column(4, "subr-egio")
+  val region     = column(5, "regi-onnn")
+  val postalCode = column(6, "post-alco")
+  val country    = column(7, "coun-tryy")
+
+  val sourceColumns = Seq(address, locality, subregion, region, postalCode, country)
+
+  // target column
+  val point = column(8, "poin-tttt")
+  val targetColId = point.userId
+
+  val columns = Seq(id, address, locality, subregion, region, postalCode, country, point)
+  val columnIdMap = columns.map(col => (col.userId, col.id.underlying)).toMap
+
+  // source column ids
+  val emptySourceColumnIds = Seq.empty
+  val sourceColumnIds = sourceColumns.map(_.userId)
+
+  // parameters
+  val emptyParameters = JObject(Map(
+    "country_default" -> JString("US")
+  ))
+
+  val parameters = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "country_default" -> JString("US")
+  ))
+
+  val parametersNoPostalCode = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "country_default" -> JString("US")
+  ))
+
+  val parametersNoCountry = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country_default" -> JString("US")
+  ))
+
+  val parametersDefaultRegion = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "region_default" -> JString("WA"),
+    "country_default" -> JString("US")
+  ))
+
+  val parametersOnlyDefaultRegion = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "region_default" -> JString("WA"),
+    "country_default" -> JString("US")
+  ))
+
+  val parametersDefaultCountry = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "country_default" -> JString("United States")
+  ))
+
+  val parametersOnlyDefaultCountry = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country_default" -> JString("United States")
+  ))
+
+  val parametersWithExtra = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JString(region.userId.underlying),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "country_default" -> JString("US"),
+    "extra" -> JNull
+  ))
+
+  val parametersMalformed = JObject(Map(
+    "address" -> JString(address.userId.underlying),
+    "locality" -> JString(locality.userId.underlying),
+    "region" -> JNumber(666),
+    "postal_code" -> JString(postalCode.userId.underlying),
+    "country" -> JString(country.userId.underlying),
+    "country_default" -> JString("US"),
+    "extra" -> JNull
+  ))
+
+  def cookieSchema(strategyInfo: ComputationStrategyInfo) = CookieSchema(
+    dataVersion = DataVersion(44),
+    copyNumber = CopyNumber(4),
+    primaryKey = id.userId,
+    columnIdMap,
+    strategyMap = Map(targetColId -> strategyInfo),
+    obfuscationKey = "obfuscate".getBytes,
+    computationRetriesLeft = 6,
+    mutationScriptRetriesLeft = 6,
+    resync = false,
+    JNull
+  )
+
+  def textOrNull(opt: Option[String]) = opt.map(SoQLText(_)).getOrElse(SoQLNull)
+
+  def row(addrOpt: Option[InternationalAddress], nullCountry: Boolean = false, postalCodeAsNumber: Boolean = false) =
+    addrOpt match {
+      case Some(addr) => ColumnIdMap(
+        id.id -> SoQLID(5),
+        address.id -> textOrNull(addr.address),
+        locality.id -> textOrNull(addr.locality),
+        subregion.id -> textOrNull(addr.subregion),
+        region.id -> textOrNull(addr.region),
+        postalCode.id -> { addr.postalCode match {
+          case Some(str) => if (postalCodeAsNumber) SoQLNumber(new java.math.BigDecimal(str)) else SoQLText(str)
+          case None => SoQLNull
+        }},
+        country.id -> { if (nullCountry) SoQLNull else SoQLText(addr.country) },
+        point.id -> SoQLNull)
+      case None =>  ColumnIdMap(
+        id.id -> SoQLID(5),
+        address.id -> SoQLNull,
+        locality.id -> SoQLNull,
+        subregion.id -> SoQLNull,
+        region.id -> SoQLNull,
+        postalCode.id -> SoQLNull,
+        country.id -> SoQLNull,
+        point.id -> SoQLNull)
+    }
+
+  // rows and addresses
+  val baseRow = ColumnIdMap(id.id -> SoQLID(5), point.id -> SoQLNull)
+
+  val emptyAddress = InternationalAddress(None, None, None, None, None, None) // actually None
+  val emptyRow = row(emptyAddress, nullCountry = true)
+  val emptyJValue = JNull
+  val usJValue = JString("POINT(36.2474412 -113.7152476)")
+
+  val socrataAddress = InternationalAddress(Some("705 5th Ave S #600"), Some("Seattle"), None, Some("WA"), Some("98104"), Some("US"))
+  val socrataRow = row(socrataAddress)
+  val socrataJValue = JString("POINT(47.5964756 -122.3303628)")
+
+  val socrataAddressNoRegion = socrataAddress.map(_.copy(region = None))
+  val socrataRowNoRegion = row(socrataAddressNoRegion)
+
+  val socrataAddressNoPostalCode = socrataAddress.map(_.copy(postalCode = None))
+
+  val socrataRowPostalCodeAsNumber = row(socrataAddress, nullCountry = false, postalCodeAsNumber = true)
+
+  val socrataRowNullCountry = row(socrataAddress, nullCountry = true)
+
+  val socrataAddressUnitedStates = socrataAddress.map(_.copy(country = "United States"))
+  val socrataRowUnitedStates = row(socrataAddressUnitedStates)
+
+  val socrataDCAddress = InternationalAddress(Some("1150 17th St NW #200"), Some("Washington"), None, Some("DC"), Some("20036"), Some("US"))
+  val socrataDCRow = row(socrataDCAddress)
+  val socrataDCJValue = JString("POINT(38.9053532 -77.0410809)")
+
+  val nowhereAddress = InternationalAddress(Some("101 Nowhere Lane"), None, None, Some("Nowhere Land"), None, Some("USA"))
+  val nowhereRow = row(nowhereAddress)
+  val nowhereJValue = JNull
+
+  val badAddress = InternationalAddress(Some("Bad Address Lane"), None, None, None, None, None)
+  val badAddressRow = row(badAddress)
+
+  val knownAddresses = Map(
+    socrataAddress -> LatLon(47.5964756, -122.3303628),
+    socrataDCAddress -> LatLon(38.9053532, -77.0410809)
+  )
+
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
* adds optional parameters to `parameters` in the
  computation strategy.
* a default value will be used in the case that
  the corresponding column does not exist or the
  value for a row is null.
* also updates to latest version of secondary-watcher