### PR TITLE
EN-7507: Use fixed library version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.0"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.9"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.10"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.5_6506_8bc696db
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.10_7592_2bbebf2f
 
 # TODO expose JMX
 # EXPOSE


### PR DESCRIPTION
New `secondarylib-feedback` version
has fix for adding to the cookie
correctly during `Secondary.version(.)`.