### PR TITLE
..and now downgrade typesafe-config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val socrataThirdPartyUtils  = "com.socrata" %% "socrata-thirdparty-utils"   % "4
 
 val socrataSoqlTypes        = "com.socrata" %% "soql-types"                 % "1.0.1" excludeAll(ExclusionRule(organization = "com.rojoma"))
 
-val typesafeConfig          = "com.typesafe" % "config"                     % "1.3.0"
+val typesafeConfig          = "com.typesafe" % "config"                     % "1.2.0"
 
 lazy val commonSettings = Seq(
   organization := "com.socrata",


### PR DESCRIPTION
Because we're still _building_ with Java 7, even though we're _deploying_
on Java 8.