### PR TITLE
EN-8588: Use fixed version of `geocoders`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val rojomaJsonV3            = "com.rojoma"  %% "rojoma-json-v3"             % "3
 
 val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0.0.4"
 
-val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.0"
+val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.1"
 
 val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.14"
 

--- a/src/main/resources/secondary-manifest.json
+++ b/src/main/resources/secondary-manifest.json
@@ -1,4 +1,0 @@
-{
-  "class" : "com.socrata.geocodingsecondary.GeocodingSecondary",
-  "name" : "geocoding"
-}


### PR DESCRIPTION
 * URL encode strings sent to MapQuest
 * Also remove unused `secondary-manifest.json` file