### PR TITLE
Serialize resource names as themselves

### DIFF
--- a/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
@@ -20,7 +20,9 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration
 
-case class ResourceName(underlying: String)
+case class ResourceName(underlying: String) {
+  override final def toString = underlying
+}
 object ResourceName extends (String => ResourceName) {
   implicit val jCodec = WrapperJsonCodec[ResourceName](this, _.underlying)
 }


### PR DESCRIPTION
For consistency with our other wrapped-string types.

Also correctness.

Sort of.