### PR TITLE
EN-6889: Use export calls to DC instead of resync

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.1"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.14"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.0.19"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 

--- a/docker/secondary.conf.j2
+++ b/docker/secondary.conf.j2
@@ -4,8 +4,8 @@ instances {
     numWorkers = {{ GEOCODING_SECONDARY_NUM_WORKERS }}
     config = {
       base-batch-size = 40000
-      mutation-script-retries = 5
-      internal-mutation-script-retries = 5
+      data-coordinator-retries = 5
+      internal-data-coordinator-retries = 5
       computation-retries = 5
 
       curator {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 com.socrata.geocoding-secondary {
   base-batch-size = 40000
-  mutation-script-retries = 5
-  internal-mutation-script-retries = 5
+  data-coordinator-retries = 5
+  internal-data-coordinator-retries = 5
   computation-retries = 5
 
   curator {

--- a/src/main/scala/com/socrata/geocodingsecondary/GeocodingSecondary.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/GeocodingSecondary.scala
@@ -45,7 +45,7 @@ class GeocodingSecondary(config: GeocodingSecondaryConfig) extends FeedbackSecon
     new OptionRemoverGeocoder(provider, multiplier = 1 /* we don't want to batch filtering out Nones */)
   }
 
-  override val retryLimit = config.computationRetries
+  override val computationRetryLimit = config.computationRetries
   override val user = "geocoding-secondary"
 
   val regionDiscoveryProvider =

--- a/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
+++ b/src/test/scala/com.socrata.geocodingsecondary/TestData.scala
@@ -141,7 +141,7 @@ object TestData {
     strategyMap = Map(targetColId -> strategyInfo),
     obfuscationKey = "obfuscate".getBytes,
     computationRetriesLeft = 6,
-    mutationScriptRetriesLeft = 6,
+    dataCoordinatorRetriesLeft = 6,
     resync = false
   )
 


### PR DESCRIPTION
Update to new version of `secondarylib-feedback`
library that implements this new functionality.