### PR TITLE
EN-6995: handle OutOfMemoryErrors gracefully

### DIFF
--- a/docker/ship.d/run
+++ b/docker/ship.d/run
@@ -19,5 +19,6 @@ exec su socrata -c '/usr/bin/java \
     -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
     -Dcom.socrata.data-coordinator.secondary-watcher.log4j.rootLogger.0=${LOG_LEVEL:-INFO} \
     -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
+    -XX:+ExitOnOutOfMemoryError \
     -jar $SERVER_ARTIFACT
     '


### PR DESCRIPTION
With Java 8, we need to add this flag to handle OutOfMemoryErrors the way we want to. Otherwise the worker threads will crash but the main thread won't.