### PR TITLE
EN-4585: Improved secondary-watcher claims

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.1.5"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.0"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 


### PR DESCRIPTION
Use new secondaryLib library version with:
 - retry logic for releasing claims
 - in memory "working set" of  claimed datasets
   to prevent from re-claiming a dataset
   whose claim we failed to release
 - health check on claim update happening
       on desired interval