### PR TITLE
EN-13225: Bump secondary-watcher version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.0"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.3"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 


### PR DESCRIPTION
Main changes:
 * secondary-watcher updates version on the secondary manifest
   in a new transaction.

Other changes:
 * restrict resync datasets of the same secondary group to happen
   one at a time. Since geocoding-secondary is not part of a group
   this shouldn't change resync behavior for the secondary.

Refs EN-13224

This depends on migration in truth to create the resync table.
568cc622e645772311af84cf7204e7dbbebc7319