### PR TITLE
EN-13224: Fix regression where resync never breaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.3"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.4"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 


### PR DESCRIPTION
Fix regression where `secondary_manifest.retry_num`
is not incremented when there is an error in resync.

The fix is in the secondary-watcher library code.