### PR TITLE
EN-12729: Avoid deadlocks with new SW lib version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.4"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.5"
 
 val socrataCuratorUtils     = "com.socrata" %% "socrata-curator-utils"      % "1.0.3"
 


### PR DESCRIPTION
Avoid deadlocks when updating multiple rows on the
`secondary_manifest` by first obtaining locks on
the rows in a deterministic order, i.e. ordery by
`dataset_system_id` then `store_id`.