### PR TITLE
EN-17842: Better logging during region-coding call

### DIFF
--- a/docker/secondary.conf.j2
+++ b/docker/secondary.conf.j2
@@ -43,20 +43,6 @@ instances {
           retry-count = 5
         }
       }
-
-      # TODO figure out right strategy for where this should go
-      log4j {
-        rootLogger = [ INFO, console ]
-        appender {
-          console.class = org.apache.log4j.ConsoleAppender
-          console.props {
-            layout.class = org.apache.log4j.PatternLayout
-            layout.props {
-              ConversionPattern = "%d %p [%t] (%X{job-id}) (%X{X-Socrata-RequestId}) [%X{dataset-id}] %c{1} %m%n"
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
@@ -88,24 +88,24 @@ abstract class AbstractRegionCodingHandler(http: HttpClient,
         }.toSeq.groupBy(_._2.endpoint).mapValuesStrictly(_.groupBy(_._1).mapValuesStrictly(_.map(_._2)))
 
       // maintain the same MDC context map for our logging
-      val orignalContextMap = MDC.getCopyOfContextMap
+      val parentContextMap = MDC.getCopyOfContextMap
 
       Right(splitSources.toSeq.par.map { case (endpoint, jobsForEndpoint) =>
         // set thread name
         val thread = Thread.currentThread()
         val name = thread.getName
-        Thread.currentThread().setName(s"Worker ${thread.getId} for parallel region-coding")
+        thread.setName(s"ThreadId:${thread.getId} parallel region-coding")
 
-        // set context map to include request id sent to region-coder
-        val contextMap = MDC.getCopyOfContextMap
-        contextMap.put(RequestId.ReqIdHeader, RequestId.generate())
-        MDC.setContextMap(contextMap)
+        // we are in a worker thread here because of the parallel call
+        MDC.setContextMap(parentContextMap)
 
-        val computed = computeOneEndpoint(endpoint, jobsForEndpoint)
-
-        // reset thread name and context map
-        thread.setName(name)
-        MDC.setContextMap(orignalContextMap)
+        val computed = try {
+          computeOneEndpoint(endpoint, jobsForEndpoint)
+        } finally {
+          // reset thread name and clear MDC
+          thread.setName(name)
+          MDC.clear()
+        }
 
         computed
       }.fold(Map.empty[RowHandle, Map[UserColumnId, SoQLValue]])(mergeWith(_, _)(_ ++ _)))
@@ -181,7 +181,7 @@ abstract class AbstractRegionCodingHandler(http: HttpClient,
           RequestBuilder(new java.net.URI(urlPrefix + endpoint)).
             connectTimeoutMS(connectTimeout.toMillis.toInt).
             receiveTimeoutMS(readTimeout.toMillis.toInt).
-            addHeader((RequestId.ReqIdHeader, MDC.get(RequestId.ReqIdHeader)))
+            addHeader((RequestId.ReqIdHeader, MDC.get("job-id")))
         for(resp <- http.execute(base.json(JValueEventIterator(allCells)))) {
           resp.resultCode match {
             case 200 =>


### PR DESCRIPTION
Properly log the job-id and dataset-id during the parallel
region coding calls and send that job-id to region coder
so we can actually correlate logs.

Remove unused log4j config from docker file.

This is for debugging failed region coding.