### PR TITLE
EN-7442: Support no source columns for geocoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.19"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.26"
 
 val javaxServlet            = "javax.servlet" % "javax.servlet-api"         % "3.1.0" // needed for socrata-http-server
 


### PR DESCRIPTION
Support geocoded computed columns without source columns.
Bring in new version of feedback library to allow this.