### PR TITLE
EN-19241: Bug fix for datasets with user PK column

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.30"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.3.32"
 
 val javaxServlet            = "javax.servlet" % "javax.servlet-api"         % "3.1.0" // needed for socrata-http-server
 


### PR DESCRIPTION
Bring in fixed feedback secondary library version with a bug
fix for datasets with user primary key columns. Always
export the system id column from data-coordinator since it
is not automatically returned for datasets with user pks.