### PR TITLE
EN-21895: Bump DC version to include collocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,18 +174,25 @@ If you want to use the geocoding secondary you will need to add a MapQuest app-t
 INSERT INTO secondary_stores_config (store_id, next_run_time, interval_in_seconds, is_feedback_secondary) VALUES( 'geocoding', now(), 5, true);
 ```
 #### MapQuest
-For `geocoding-secondary` to use MapQuest add to your config under `com.socrata.geocoding-secondary.geocoder`
+For `geocoding-secondary` to use MapQuest create the .gitignored local override file `configs/local-geocoding-secondary.conf`
+and override the value for `com.socrata.geocoding-secondary.geocoder.mapquest.app-token` with a real MapQuest app token.
 ```
-mapquest {
-  app-token = "SOME MAPQUEST APP TOKEN"
-  retry-count = 5
+> cat configs/local-geocoding-secondary.conf
+com.socrata.geocoding-secondary {
+  geocoder.mapquest.app-token = "SOME REAL MAPQUEST APP TOKEN"
 }
 ```
 
 ### Running
+With `sbt`:
+```
+> sbt -Dconfig.file=configs/application.conf run
+```
+
+Running the assembled jarfile:
 ```
 > sbt assembly
-> java -Djava.net.preferIPv4Stack=true -Dconfig.file=/etc/geocoding-secondary.conf -jar target/scala-2.10/secondary-watcher-geocoding-assembly-0.0.12-SNAPSHOT.jar
+> java -Djava.net.preferIPv4Stack=true -Dconfig.file=configs/application.conf -jar target/scala-2.10/secondary-watcher-geocoding-assembly-<version>-SNAPSHOT.jar
 ```
 
 ## Tests

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val computationStrategies   = "com.socrata" %% "computation-strategies"     % "0
 
 val geocoders               = "com.socrata" %% "geocoders"                  % "2.0.7"
 
-val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.4.3"
+val dataCoordinator         = "com.socrata" %% "secondarylib-feedback"      % "3.4.10"
 
 val javaxServlet            = "javax.servlet" % "javax.servlet-api"         % "3.1.0" // needed for socrata-http-server
 

--- a/configs/application-alpha.conf
+++ b/configs/application-alpha.conf
@@ -2,5 +2,6 @@ include "application.conf"
 
 com.socrata.coordinator.secondary-watcher {
   instance = alpha
+  collocation.group = [alpha,bravo,charlie]
   database.database = datacoordinator_alpha
 }

--- a/configs/application-bravo.conf
+++ b/configs/application-bravo.conf
@@ -2,5 +2,6 @@ include "application.conf"
 
 com.socrata.coordinator.secondary-watcher {
   instance = bravo
+  collocation.group = [alpha,bravo,charlie]
   database.database = datacoordinator_bravo
 }

--- a/configs/application-charlie.conf
+++ b/configs/application-charlie.conf
@@ -2,5 +2,6 @@ include "application.conf"
 
 com.socrata.coordinator.secondary-watcher {
   instance = charlie
+  collocation.group = [alpha,bravo,charlie]
   database.database = datacoordinator_charlie
 }

--- a/configs/sample-geocoding-secondary.conf
+++ b/configs/sample-geocoding-secondary.conf
@@ -18,6 +18,10 @@ com.socrata.coordinator.secondary-watcher = {
 
   instance = primus
 
+  curator.ensemble = ["localhost:2181"]
+  service-advertisement.address = "local.dev.socrata.net"
+  collocation.group = [primus]
+
   secondary {
     # unused
     defaultGroups = []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,7 @@ ENV SERVER_CONFIG secondary-watcher.conf
 
 # general secondary-watcher defaults
 ENV TRUTH_CLUSTER alpha
+ENV TRUTH_CLUSTER_COLLOCATION_GROUP [alpha]
 ENV ENABLE_GRAPHITE false
 ENV GRAPHITE_HOST 0.0.0.0
 ENV GRAPHITE_PORT 0

--- a/docker/secondary-watcher.conf.j2
+++ b/docker/secondary-watcher.conf.j2
@@ -3,6 +3,10 @@
 com.socrata.coordinator.secondary-watcher {
   instance = "{{ TRUTH_CLUSTER }}"
 
+  curator.ensemble = {{ ZOOKEEPER_ENSEMBLE }}
+  service-advertisement.address = "{{ ARK_HOST }}"
+  collocation.group = {{ TRUTH_CLUSTER_COLLOCATION_GROUP }}
+
   # So we have good news and bad news.
   # The bad news is in the docker world we don't have the notion of an instance that will come back and 
   # reclaim its work based on its own uuid when it restarts, ever new container will have a new uuid.


### PR DESCRIPTION
Bump data-coordinatory library version to inlcude collocation work and
make needed config file additions. So we don't have to deal with this
later when pulling in needed SecondaryWatcher / FeedbackSecondary
library changes.

Also, update README's run instructions to refer to the local
checked-in configuration file `configs/application.conf`.
(See EN-21594)