### PR TITLE
EN-22044: Explicit use of local.dev.socrata.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ target/
 /test-out/
 .idea*/
 sbt-test.log
-configs/local-geocoding-secondary.conf
+configs/local*.conf
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ If you want to use the geocoding secondary you will need to add a MapQuest app-t
 INSERT INTO secondary_stores_config (store_id, next_run_time, interval_in_seconds, is_feedback_secondary) VALUES( 'geocoding', now(), 5, true);
 ```
 #### MapQuest
-For `geocoding-secondary` to use MapQuest create the .gitignored local override file `configs/local-geocoding-secondary.conf`
+For `geocoding-secondary` to use MapQuest create the .gitignored local override file `configs/local.conf`
 and override the value for `com.socrata.geocoding-secondary.geocoder.mapquest.app-token` with a real MapQuest app token.
 ```
-> cat configs/local-geocoding-secondary.conf
+> cat configs/local.conf
 com.socrata.geocoding-secondary {
   geocoder.mapquest.app-token = "SOME REAL MAPQUEST APP TOKEN"
 }

--- a/configs/application.conf
+++ b/configs/application.conf
@@ -1,6 +1,6 @@
 # Sensible defaults for a development environment
-include "sample-geocoding-secondary.conf"
+include "sample.conf"
 
 # This file is .gitignored; you can create it and make
 # any changes you like there.
-include "local-geocoding-secondary.conf"
+include "local.conf"

--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -1,8 +1,15 @@
+# use local.dev.socrata.net to support solo which resolves to 127.0.0.1
+common-host = "local.dev.socrata.net"
+common-zk-host = "local.dev.socrata.net:2181"
+common-zk-ensemble = ["local.dev.socrata.net:2181"]
+common-cassandra-ensemble = ["local.dev.socrata.net:9160"]
+common-amq-conn-str = "tcp://local.dev.socrata.net:61616"
+
 com.socrata.coordinator.secondary-watcher = {
   database = {
     app-name = secondary-watcher-geocoding
     database = datacoordinator
-    host = localhost
+    host = ${common-host}
     port = 5432
     username = blist
     password = blist
@@ -18,8 +25,8 @@ com.socrata.coordinator.secondary-watcher = {
 
   instance = primus
 
-  curator.ensemble = ["localhost:2181"]
-  service-advertisement.address = "local.dev.socrata.net"
+  curator.ensemble = ${common-zk-ensemble}
+  service-advertisement.address = ${common-host}
   collocation.group = [primus]
 
   secondary {
@@ -51,11 +58,11 @@ com.socrata.coordinator.secondary-watcher = {
   message-producer {
     eurybates {
       producers = "activemq"
-      activemq.connection-string = "tcp://localhost:61616"
+      activemq.connection-string = ${common-amq-conn-str}
     }
 
     zookeeper {
-      conn-spec = "localhost:2181"
+      conn-spec = ${common-zk-host}
       session-timeout = 4s
     }
   }
@@ -77,9 +84,9 @@ com.socrata.coordinator.secondary-watcher = {
 }
 
 com.socrata.geocoding-secondary {
-  cassandra.connection-pool.seeds = [ "127.0.0.1:9160" ]
+  cassandra.connection-pool.seeds = ${common-cassandra-ensemble}
 
-  curator.ensemble = ["localhost:2181"]
+  curator.ensemble = ${common-zk-ensemble}
 
   geocoder.mapquest.app-token = SOME_APP_TOKEN # you will need to find a real MapQuest app token and override this
 }


### PR DESCRIPTION
Clearly comment that it was for solo (becaus I was confused).
Also, a little bit of config renaming to match spandex based
off of code reviews there.

Note: still need to actually setup solo for this service.