### PR TITLE
EN-28704 Preserve original computed value (point) if source columns (…

### DIFF
--- a/src/main/scala/com/socrata/geocodingsecondary/GeocodingHandler.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/GeocodingHandler.scala
@@ -101,6 +101,9 @@ class GeocodingHandler(geocoder: OptionalGeocoder) extends ComputationHandler[So
         val soqlValues = (sources,pointsHere).zipped.map { (source, point) =>
           val targetVal = source.targetValue match {
             case SoQLNull =>
+              // When custom geocoder is used in dsmapi that returns a null point and our standard geocoder returns a non null point,
+              // this will undesirably override the custom geocoder result with our standard result.
+              // TODO: Add custom geocoder capability to secondary-watcher-geocoding is a solution.
               point.fold[SoQLValue](SoQLNull) { case LatLon(lat, lon) =>
                 SoQLPoint(geometryFactory.get.createPoint(new Coordinate(lon, lat))) // Not at all sure this is correct!
               }

--- a/src/main/scala/com/socrata/geocodingsecondary/GeocodingHandler.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/GeocodingHandler.scala
@@ -41,7 +41,7 @@ case class GeocodeColumnInfo(cookie: CookieSchema, strategy: ComputationStrategy
     }
   }
 }
-case class GeocodeRowInfo(address: Option[InternationalAddress], data: secondary.Row[SoQLValue], targetColId: UserColumnId)
+case class GeocodeRowInfo(address: Option[InternationalAddress], data: secondary.Row[SoQLValue], targetColId: UserColumnId, targetValue: SoQLValue)
 
 class GeocodingHandler(geocoder: OptionalGeocoder) extends ComputationHandler[SoQLType, SoQLValue] {
   type PerDatasetData = CookieSchema
@@ -77,7 +77,9 @@ class GeocodingHandler(geocoder: OptionalGeocoder) extends ComputationHandler[So
           country.orElse(Some(colInfo.parameters.defaults.country)))
       }
 
-    GeocodeRowInfo(internationalAddress, row, colInfo.targetColId)
+    val targetColumnId = colInfo.cookie.columnIdMap(colInfo.targetColId)
+    val targetValue = row(targetColumnId)
+    GeocodeRowInfo(internationalAddress, row, colInfo.targetColId, targetValue)
   }
 
   override def compute[RowHandle](sources: Map[RowHandle, Seq[GeocodeRowInfo]]): Either[ComputationFailure, Map[RowHandle, Map[UserColumnId, SoQLValue]]] = {
@@ -97,9 +99,15 @@ class GeocodingHandler(geocoder: OptionalGeocoder) extends ComputationHandler[So
         val (pointsHere, leftoverPoints) = points.splitAt(sources.length)
         assert(pointsHere.length == sources.length, "Geocoding returned too few results?")
         val soqlValues = (sources,pointsHere).zipped.map { (source, point) =>
-          source.targetColId -> point.fold[SoQLValue](SoQLNull) { case LatLon(lat, lon) =>
-            SoQLPoint(geometryFactory.get.createPoint(new Coordinate(lon, lat))) // Not at all sure this is correct!
+          val targetVal = source.address match {
+            case None => // Keep origin target value if source address is null
+              source.targetValue
+            case Some(_) =>
+              point.fold[SoQLValue](SoQLNull) { case LatLon(lat, lon) =>
+                SoQLPoint(geometryFactory.get.createPoint(new Coordinate(lon, lat))) // Not at all sure this is correct!
+              }
           }
+          source.targetColId -> targetVal
         }.toMap
         val newAcc = acc + (row -> soqlValues)
         (newAcc, leftoverPoints)


### PR DESCRIPTION
…address) are null.

Add target value to gecoderowinfo class