### PR TITLE
EN-40040: Send the job id _as_ the job ID, not request ID

### DIFF
--- a/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
+++ b/src/main/scala/com/socrata/geocodingsecondary/RegionCodingHandler.scala
@@ -185,7 +185,7 @@ abstract class AbstractRegionCodingHandler(http: HttpClient,
           RequestBuilder(new java.net.URI(urlPrefix + endpoint)).
             connectTimeoutMS(connectTimeout.toMillis.toInt).
             receiveTimeoutMS(readTimeout.toMillis.toInt).
-            addHeader((RequestId.ReqIdHeader, MDC.get("job-id")))
+            addHeader(("X-Socrata-JobId", MDC.get("job-id")))
         for(resp <- http.execute(base.json(JValueEventIterator(cells)))) {
           resp.resultCode match {
             case 200 =>


### PR DESCRIPTION
There's a corresponding commit in region-coder to understand this.